### PR TITLE
Adding ability for custom error messages at source

### DIFF
--- a/src/lib/validation.spec.ts
+++ b/src/lib/validation.spec.ts
@@ -26,14 +26,14 @@ const onlyNumbers = Validation(
 );
 
 const schema: Schema = {
-  name: { initial: '', validations: [isPresent, maxChars(30), minChars(3)] },
+  name: { initial: '', validations: [isPresent(), maxChars(30), minChars(3)] },
   password: {
     initial: '',
-    validations: [isPresent, minChars(8), maxChars(30), onlyNumbers],
+    validations: [isPresent(), minChars(8), maxChars(30), onlyNumbers],
   },
-  tos: { initial: false, validations: [isTrue] },
+  tos: { initial: false, validations: [isTrue()] },
   age: { initial: 0, validations: [minVal(18), maxVal(40)] },
-  email: { initial: '', validations: [isPresent, isEmail] },
+  email: { initial: '', validations: [isPresent(), isEmail()] },
   limit: { initial: 200, validations: [maxVal(500)] },
 };
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,6 +1,4 @@
 /* eslint-disable functional/no-mixed-type */
-import { List } from 'immutable-ext';
-
 type Input = Record<string, unknown>;
 type SuccessfulOutput = Input;
 type FailedOutput = Record<string, readonly string[]>;
@@ -65,8 +63,9 @@ const mergeFailures = (
   );
 
 const validate = (schema: Schema, obj: Input): Result =>
-  List(Object.keys(schema)).foldMap(
-    (key: string) => schema[key].validations.reduce(concat).run(key, obj[key]),
+  Object.keys(schema).reduce(
+    (acc, key) =>
+      acc.concat(schema[key].validations.reduce(concat).run(key, obj[key])),
     Success(obj)
   );
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,56 +1,67 @@
 import { Fail, Runner, Success, Validation } from './validation';
 
 export const pattern =
-  (re: RegExp, message: string): Runner =>
+  (re: RegExp, errorMessage: string): Runner =>
   (key, x) =>
     typeof x !== 'string'
       ? Fail({ [key]: [`${key} must be a string`] })
       : re.test(x)
       ? Success()
-      : Fail({ [key]: [`${key}: ${message}`] });
+      : Fail({ [key]: [`${key}: ${errorMessage ?? `${key} bad format`}`] });
 
-export const isPresent = Validation((key, x) =>
-  x ? Success() : Fail({ [key]: [`${key} is not present`] })
-);
+export const isPresent = (errorMessage?: string) =>
+  Validation((key, x) =>
+    x ? Success() : Fail({ [key]: [errorMessage ?? `${key} is not present`] })
+  );
 
-export const isEmail = Validation(pattern(/@/, 'bad email format'));
+export const isEmail = (errorMessage?: string) =>
+  Validation(pattern(/@/, errorMessage ?? 'Bad email format'));
 
-export const isTrue = Validation((key, x) =>
-  x === true ? Success() : Fail({ [key]: [`${key} must be set`] })
-);
+export const isTrue = (errorMessage?: string) =>
+  Validation((key, x) =>
+    x === true
+      ? Success()
+      : Fail({ [key]: [errorMessage ?? `${key} must be set`] })
+  );
 
-export const maxChars = (max: number) =>
+export const maxChars = (max: number, errorMessage?: string) =>
   Validation((key, x) =>
     typeof x !== 'string'
       ? Fail({ [key]: [`${key} must be a string`] })
       : x.length < max
       ? Success()
-      : Fail({ [key]: [`${key} has to be shorter than ${max} chars`] })
+      : Fail({
+          [key]: [errorMessage ?? `${key} has to be shorter than ${max} chars`],
+        })
   );
 
-export const minChars = (min: number) =>
+export const minChars = (min: number, errorMessage?: string) =>
   Validation((key, x) =>
     typeof x !== 'string'
       ? Fail({ [key]: [`${key} must be a string`] })
       : x.length >= min
       ? Success()
-      : Fail({ [key]: [`${key} has to be greater than ${min} chars`] })
+      : Fail({
+          [key]: [errorMessage ?? `${key} has to be greater than ${min} chars`],
+        })
   );
 
-export const minVal = (min: number) =>
+export const minVal = (min: number, errorMessage?: string) =>
   Validation((key, x) =>
     typeof x !== 'number'
       ? Fail({ [key]: [`${key} must be a number`] })
       : x >= min
       ? Success()
-      : Fail({ [key]: [`${key} has to be greater than ${min}`] })
+      : Fail({
+          [key]: [errorMessage ?? `${key} has to be greater than ${min}`],
+        })
   );
 
-export const maxVal = (max: number) =>
+export const maxVal = (max: number, errorMessage?: string) =>
   Validation((key, x) =>
     typeof x !== 'number'
       ? Fail({ [key]: [`${key} must be a number`] })
       : x <= max
       ? Success()
-      : Fail({ [key]: [`${key} has to be less than ${max}`] })
+      : Fail({ [key]: [errorMessage ?? `${key} has to be less than ${max}`] })
   );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature

- **What is the current behavior?** (You can also link to an open issue here)
- The user of the library must use the same canned error messages for the provided validators

- **What is the new behavior (if this is a feature change)?**
- all provided validators take an optional errorMessage argument that replaces the canned error message when provided.

- **Other information**:
- usage:
- email: { initial: '', validations: [isPresent("email must be provided"), isEmail()] }
